### PR TITLE
Small changes for consistency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,6 @@ python:
   - "3.3"
   - "3.4"
 
-before_install:
-  - sudo add-apt-repository -y ppa:ubuntugis/ppa
-  - sudo apt-get update -qq
-  - sudo apt-get install -y libgdal1h gdal-bin libgdal-dev
-
 install:
   - pip install -e .[test]
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: python
 
 python:
   - "2.7"
-  - "3.3"
-  - "3.4"
+  #- "3.3"
+  #- "3.4"
 
 install:
   - pip install -e .[test]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,7 +7,7 @@ import tempfile
 
 from click.testing import CliRunner
 import gpsdio_sort.core
-import gpsdio
+import gpsdio.cli
 import os.path
 import datetime
 import random
@@ -32,20 +32,23 @@ def test_sort():
     cleanup()
     try:
         with gpsdio.open("in.msg", "w") as f:
-            for i in xrange(0, 1000):
+            for i in range(0, 1000):
                 f.writerow({'timestamp': randdate(), 'lat': 180*random.random()-90.0, 'lon': 360*random.random()-180.0})
 
-        result = CliRunner().invoke(gpsdio_sort.core.gpsdio_sort, [
-                '-c', 'timestamp',
-                'in.msg',
-                'out.msg',
-                ])
+        result = CliRunner().invoke(gpsdio.cli.main.main_group, [
+            '--i-drv', 'MsgPack',
+            '--o-drv', 'MsgPack',
+            'sort',
+            '-c', 'timestamp',
+            'in.msg',
+            'out.msg',
+        ])
         
         last = None
         with gpsdio.open('out.msg') as f:
             for row in f:
                 if last is not None:
-                    print row
+                    print(row)
                     assert last['timestamp'] < row['timestamp']
                 last = row
     finally:


### PR DESCRIPTION
- Enable Travis-CI and coveralls.io (but only for Python2 until gpsdio does Py3).  Removed GDAL install from `.travis.yml`.
- A short description that doesn't get truncated in `gpsdio --help`.
- Added note about using unix sort and potentially large tempfiles.
- Added a check to make sure `sort` is on the path and executable.
- Flags like `gpsdio --i-drv` are now passed to `gpsdio.open()`.
